### PR TITLE
Fixes event feed images being out of order

### DIFF
--- a/src/templates/blocks/blocks/event-feed.js
+++ b/src/templates/blocks/blocks/event-feed.js
@@ -53,7 +53,8 @@ const BlockEventFeed = ({ events, title, limit }) => {
   const displayEvents = []
   events.forEach(event => {
     if (displayEvent(event) && displayEvents.length <= limit) {
-      event.nextEventDate = getNextEventDate(event.dates)
+      const momentDate = getNextEventDate(event.dates)
+      event.nextEventDate = momentDate.valueOf()
       displayEvents.push(event)
     }
   })
@@ -62,8 +63,8 @@ const BlockEventFeed = ({ events, title, limit }) => {
   }
   let sortedEvents = displayEvents.sort((a, b) => {
     if (
-      typeof a.dates[0] === 'undefined' ||
-      typeof b.dates[0] === 'undefined'
+      typeof a.nextEventDate === 'undefined' ||
+      typeof b.nextEventDate === 'undefined'
     ) {
       return 0
     }


### PR DESCRIPTION
Fixes #496 

Turns out this was a Javascript specific issue  - the events were being sorted and displayed by their Moment date object, when they should have been using the numerical value of that object. For whatever reason, it still eventually figured out the value, but there was a brief hiccup which caused events to be added in at the last minute. I used the value of the next event date instead, and that fixed the issue.