### PR TITLE
Revert changes to event feed sorting-caused bugs

### DIFF
--- a/src/templates/blocks/blocks/event-feed.js
+++ b/src/templates/blocks/blocks/event-feed.js
@@ -22,39 +22,10 @@ const displayEvent = item => {
   return display
 }
 
-const getNextEventDate = dates => {
-  let nextDate = false
-  let lastDate = false
-  let now = moment()
-  dates.map(date => {
-    const start = moment(date.start)
-    if (!nextDate) {
-      nextDate = start
-    }
-    const diff = start.diff(now)
-    if (!lastDate || lastDate.diff(now) < diff) {
-      lastDate = start
-    }
-    if (diff > -1 && (nextDate.diff(now) < -1 || diff < nextDate.diff(now))) {
-      nextDate = start
-    }
-    return nextDate
-  })
-  if (!nextDate) {
-    nextDate = lastDate
-  }
-  if (nextDate) {
-    return nextDate
-  }
-  return null
-}
-
 const BlockEventFeed = ({ events, title, limit }) => {
   const displayEvents = []
   events.forEach(event => {
     if (displayEvent(event) && displayEvents.length <= limit) {
-      const momentDate = getNextEventDate(event.dates)
-      event.nextEventDate = momentDate.valueOf()
       displayEvents.push(event)
     }
   })
@@ -63,13 +34,13 @@ const BlockEventFeed = ({ events, title, limit }) => {
   }
   let sortedEvents = displayEvents.sort((a, b) => {
     if (
-      typeof a.nextEventDate === 'undefined' ||
-      typeof b.nextEventDate === 'undefined'
+      typeof a.dates[0] === 'undefined' ||
+      typeof b.dates[0] === 'undefined'
     ) {
       return 0
     }
-    let aStart = a.nextEventDate
-    let bStart = b.nextEventDate
+    let aStart = moment(a.dates[0].start, 'YYYY-MM-DD').valueOf()
+    let bStart = moment(b.dates[0].start, 'YYYY-MM-DD').valueOf()
     return aStart < bStart ? -1 : aStart > bStart ? 1 : 0
   })
 


### PR DESCRIPTION
Looks like this was introduced a couple weeks ago when I switched to sorting events by the next event date, rather than the first event date in recurring events. I reverted it for now to fix #496 , and will try to find a solid fix for the sorting issue sometime in the future. For now recurring events will show up at the top of event feeds regardless of their place in the feed chronologically, not the biggest deal right now. 