### PR TITLE
Fix mobile menu toggle link alignment issues

### DIFF
--- a/src/components/layouts/sections/header/mobile.js
+++ b/src/components/layouts/sections/header/mobile.js
@@ -77,6 +77,7 @@ const SiteNavigationList = styled('ul')`
 
 const MobileSiteNavigationMenuToggle = styled('button')`
   background: transparent;
+  text-align: left;
   border: none;
   cursor: pointer;
   padding: 0;


### PR DESCRIPTION
Closes #506 - left aligns all mobile toggle menu links, even when the arrow overflows to the next line. Previously if a toggle link was too long to fit on one line, the carat would drop below and the link would become center aligned, rather than left aligned.

This makes more sense with our UI, and ensures all links begin on the same margin.